### PR TITLE
A couple of small aviary fixes to deal with solver convergence issues.

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -962,7 +962,11 @@ class AviaryProblem(om.Problem):
             if phase_idx > 0:
                 input_initial = True
 
-            if fix_initial or input_initial:
+            if self.mission_method is SOLVED_2DOF:
+                # Solved 2DOF sets its own time options.
+                pass
+            
+            elif fix_initial or input_initial:
 
                 if self.comm.size > 1:
                     # Phases are disconnected to run in parallel, so initial ref is valid.

--- a/aviary/mission/gasp_based/ode/unsteady_solved/unsteady_solved_ode.py
+++ b/aviary/mission/gasp_based/ode/unsteady_solved/unsteady_solved_ode.py
@@ -245,8 +245,8 @@ class UnsteadySolvedODE(BaseODE):
                                          lhs_name="dgam_dt_approx",
                                          rhs_name="dgam_dt",
                                          eq_units="rad/s",
-                                         lower=-np.pi/12,
-                                         upper=np.pi/12,
+                                         #lower=-np.pi/12,
+                                         #upper=np.pi/12,
                                          normalize=False)
 
         thrust_alpha_bal.add_balance("thrust_req",

--- a/aviary/mission/twodof_phase.py
+++ b/aviary/mission/twodof_phase.py
@@ -72,7 +72,7 @@ class TwoDOFPhase(FlightPhaseBase):
             phase.add_polynomial_control("alpha",
                                          order=control_order,
                                          fix_initial=True,
-                                         lower=0., upper=15.,
+                                         lower=0., upper=25.,
                                          units='deg', ref=10.,
                                          val=0.,
                                          opt=True)

--- a/aviary/mission/twodof_phase.py
+++ b/aviary/mission/twodof_phase.py
@@ -72,7 +72,7 @@ class TwoDOFPhase(FlightPhaseBase):
             phase.add_polynomial_control("alpha",
                                          order=control_order,
                                          fix_initial=True,
-                                         lower=0., upper=25.,
+                                         lower=0., upper=15.,
                                          units='deg', ref=10.,
                                          val=0.,
                                          opt=True)


### PR DESCRIPTION
### Summary

1. Removed the upper and lower bounds for angle of attack from the solver. It is probably better for those to be dealt with using constraints rather than letting the solver iterate forver.
2. Fixed a bug that overwrote the ref0 on time options.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None